### PR TITLE
Add GitHub repository discovery for catalog entities

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @osinfra-io/platform-backstage
+* @Copilot

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## 📄 Repository Description
 
-This repository manages Backstage resources.
+This repository manages Backstage resources. It provides a centralized repository for managing all Backstage configurations, plugins, and customizations. It runs on Google Kubernetes Engine (GKE) and leverages various Google Cloud Platform (GCP) services for scalability and reliability. It depends on [google-kubernetes-engine](https://github.com/osinfra-io/google-kubernetes-engine) for cluster provisioning and onboarding of namespaces.
+
+The continuous delivery workflows are implemented using GitHub Actions, ensuring testing, building, and deployment of Backstage components.
 
 ## 🏭 Platform Information
 

--- a/app/app-config.yaml
+++ b/app/app-config.yaml
@@ -123,6 +123,18 @@ catalog:
         frequency: { minutes: 02 }
         timeout: { minutes: 60 }
 
+    github:
+      osinfraOrg:
+        organization: osinfra-io
+        catalogPath: /catalog-info.yaml
+        filters:
+          branch: main
+          repository: ".*" # Import from all repositories
+        schedule:
+          initialDelay: { seconds: 30 }
+          frequency: { minutes: 05 }
+          timeout: { minutes: 50 }
+
   import:
     entityFilename: catalog-info.yaml
     pullRequestBranchName: backstage-integration

--- a/app/app-config.yaml
+++ b/app/app-config.yaml
@@ -129,11 +129,11 @@ catalog:
         catalogPath: /catalog-info.yaml
         filters:
           branch: main
-          repository: ".*" # Import from all repositories
+          repository: ".*"
         schedule:
           initialDelay: { seconds: 30 }
-          frequency: { minutes: 05 }
-          timeout: { minutes: 50 }
+          frequency: { minutes: 02 }
+          timeout: { minutes: 60 }
 
   import:
     entityFilename: catalog-info.yaml

--- a/app/packages/backend/src/index.ts
+++ b/app/packages/backend/src/index.ts
@@ -46,6 +46,7 @@ backend.add(
   import('@backstage/plugin-catalog-backend-module-scaffolder-entity-model'),
 );
 backend.add(import('@backstage/plugin-catalog-backend-module-github-org'));
+backend.add(import('@backstage/plugin-catalog-backend-module-github'));
 backend.add(githubOrgModule);
 
 // See https://backstage.io/docs/features/software-catalog/configuration#subscribing-to-catalog-errors

--- a/deployments/regional/helm/backstage.yml
+++ b/deployments/regional/helm/backstage.yml
@@ -82,6 +82,18 @@ backstage:
             frequency: { minutes: 05 }
             timeout: { minutes: 50 }
 
+        github:
+          osinfraOrg:
+            organization: osinfra-io
+            catalogPath: /catalog-info.yaml
+            filters:
+              branch: main
+              repository: ".*"
+            schedule:
+              initialDelay: { seconds: 30 }
+              frequency: { minutes: 05 }
+              timeout: { minutes: 50 }
+
       import:
         entityFilename: catalog-info.yaml
         pullRequestBranchName: backstage-integration

--- a/deployments/regional/helm/backstage.yml
+++ b/deployments/regional/helm/backstage.yml
@@ -79,8 +79,8 @@ backstage:
           orgs: [osinfra-io]
           schedule:
             initialDelay: { seconds: 30 }
-            frequency: { minutes: 05 }
-            timeout: { minutes: 50 }
+            frequency: { minutes: 15 }
+            timeout: { minutes: 60 }
 
         github:
           osinfraOrg:
@@ -91,8 +91,8 @@ backstage:
               repository: ".*"
             schedule:
               initialDelay: { seconds: 30 }
-              frequency: { minutes: 05 }
-              timeout: { minutes: 50 }
+              frequency: { minutes: 15 }
+              timeout: { minutes: 60 }
 
       import:
         entityFilename: catalog-info.yaml


### PR DESCRIPTION
This pull request introduces improvements to the management and integration of Backstage resources, focusing on enhanced GitHub organization catalog support and improved documentation. The main changes include adding GitHub organization catalog ingestion, updating deployment and configuration files, and expanding the repository documentation to clarify infrastructure and workflows.

**GitHub Organization Catalog Integration:**

* Added support for ingesting catalog data from the `osinfra-io` GitHub organization by introducing a new `github` source under the `catalog` configuration in `app/app-config.yaml`, specifying repository filters, scheduling, and organization details.
* Mirrored the above GitHub catalog ingestion configuration in the Helm deployment file `deployments/regional/helm/backstage.yml` to ensure consistency across environments.
* Enabled the `@backstage/plugin-catalog-backend-module-github` plugin in `app/packages/backend/src/index.ts` to support the new GitHub catalog ingestion.

**Documentation Improvements:**

* Expanded the `README.md` to provide a more comprehensive description of the repository, including its use of GKE, GCP services, dependency on the `google-kubernetes-engine` repo, and details about continuous delivery workflows with GitHub Actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a GitHub catalog provider for the osinfra-io organization to ingest per-repository catalog files.
  - Enabled backend integration to support the new provider.
  - Updated scheduled syncing: existing GitHub org cadence increased to 15 minutes; new provider syncs every 15 minutes with a 30s initial delay and 60m timeout.

- **Documentation**
  - Expanded repository description describing centralized Backstage management, GKE/GCP hosting, cluster provisioning dependency, and CI/CD via GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->