### PR TITLE
Fix font clipping and improve the appearance and usability of the Backstage sidebar submenu

### DIFF
--- a/app/packages/app/src/themes/osinfra.ts
+++ b/app/packages/app/src/themes/osinfra.ts
@@ -63,7 +63,6 @@ export const osinfraTheme = createUnifiedTheme({
 
 				// Target the specific Backstage sidebar submenu for "My Groups"
 				'div[class*="BackstageSidebarSubmenu-drawer"][class*="BackstageSidebarSubmenu-drawerOpen"]': {
-					maxWidth: '400px',
 					width: '400px',
 				},
 

--- a/app/packages/app/src/themes/osinfra.ts
+++ b/app/packages/app/src/themes/osinfra.ts
@@ -62,13 +62,13 @@ export const osinfraTheme = createUnifiedTheme({
 				'@font-face': [openSansCustomFont],
 
 				// Target the specific Backstage sidebar submenu for "My Groups"
-				'[class*="BackstageSidebarSubmenu-drawer"]': {
-					maxWidth: '400px !important',
-					width: '400px !important',
+				'div[class*="BackstageSidebarSubmenu-drawer"][class*="BackstageSidebarSubmenu-drawerOpen"]': {
+					maxWidth: '400px',
+					width: '400px',
 				},
 
 				// Target text elements within the sidebar submenu for line-height
-				'[class*="BackstageSidebarSubmenu-drawer"] span': {
+				'div[class*="BackstageSidebarSubmenu-drawer"] span': {
 					lineHeight: '1.4',
 				},
 			},

--- a/app/packages/app/src/themes/osinfra.ts
+++ b/app/packages/app/src/themes/osinfra.ts
@@ -69,7 +69,7 @@ export const osinfraTheme = createUnifiedTheme({
 
 				// Target text elements within the sidebar submenu for line-height
 				'[class*="BackstageSidebarSubmenu-drawer"] span': {
-					lineHeight: '1.4 !important',
+					lineHeight: '1.4',
 				},
 			},
 		},

--- a/app/packages/app/src/themes/osinfra.ts
+++ b/app/packages/app/src/themes/osinfra.ts
@@ -52,12 +52,18 @@ export const osinfraTheme = createUnifiedTheme({
 					backgroundImage: 'unset',
 					boxShadow: 'unset',
 				}),
-
+				title: () => ({
+					lineHeight: '1.3',
+				}),
 			},
 		},
 		MuiCssBaseline: {
 			styleOverrides: {
 				'@font-face': [openSansCustomFont],
+
+				'span, div, p, a, button': {
+					lineHeight: '1.4 !important',
+				},
 			},
 		},
 	},

--- a/app/packages/app/src/themes/osinfra.ts
+++ b/app/packages/app/src/themes/osinfra.ts
@@ -61,7 +61,14 @@ export const osinfraTheme = createUnifiedTheme({
 			styleOverrides: {
 				'@font-face': [openSansCustomFont],
 
-				'span, div, p, a, button': {
+				// Target the specific Backstage sidebar submenu for "My Groups"
+				'[class*="BackstageSidebarSubmenu-drawer"]': {
+					maxWidth: '400px !important',
+					width: '400px !important',
+				},
+
+				// Target text elements within the sidebar submenu for line-height
+				'[class*="BackstageSidebarSubmenu-drawer"] span': {
 					lineHeight: '1.4 !important',
 				},
 			},


### PR DESCRIPTION
This pull request updates the `osinfraTheme` configuration to improve the appearance and usability of the Backstage sidebar submenu. The most important changes focus on adjusting styles for better readability and layout.

Sidebar submenu styling improvements:

* Added a style override to set the maximum width and width of the Backstage sidebar submenu drawer to `400px`, ensuring consistent sizing and preventing overflow.
* Adjusted line height for text elements within the sidebar submenu to `1.4` for improved readability.

Typography adjustments:

* Added a `title` style override to set the line height to `1.3`, enhancing the appearance of titles.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Tightened header title line height for a more compact appearance.
  * Limited sidebar submenu width to 400px for consistent layout.
  * Standardized submenu text line height for improved readability and visual balance.
  * Visual-only updates; no changes to functionality or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->