### PR TITLE
Rename opentofu-* child module source references to pt-arche-*

### DIFF
--- a/deployments/backend.tofu
+++ b/deployments/backend.tofu
@@ -1,1 +1,13 @@
-shared/backend.tofu
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
+terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
+  backend "gcs" {
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
+  }
+}

--- a/deployments/helpers.tofu
+++ b/deployments/helpers.tofu
@@ -1,1 +1,11 @@
-shared/helpers.tofu
+# OpenTofu Core Helpers Module (osinfra.io)
+# https://github.com/osinfra-io/pt-arche-core-helpers
+
+module "helpers" {
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+
+  cost_center         = "x001"
+  data_classification = "public"
+  repository          = "backstage"
+  team                = "platform-backstage"
+}

--- a/deployments/main.tofu
+++ b/deployments/main.tofu
@@ -1,8 +1,8 @@
 # Datadog Google Cloud Platform Integration Module (osinfra.io)
-# https://github.com/osinfra-io/opentofu-datadog-google-integration
+# https://github.com/osinfra-io/pt-arche-datadog-google-integration
 
 module "datadog" {
-  source = "github.com/osinfra-io/opentofu-datadog-google-integration?ref=3e87e321842678ad478ba2c8d007a7685338e8d7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=3e87e321842678ad478ba2c8d007a7685338e8d7" # v0.3.5
   count  = var.datadog_enable ? 1 : 0
 
   api_key                            = var.datadog_api_key
@@ -13,10 +13,10 @@ module "datadog" {
 }
 
 # Google Project Module (osinfra.io)
-# https://github.com/osinfra-io/opentofu-google-project
+# https://github.com/osinfra-io/pt-arche-google-project
 
 module "project" {
-  source = "github.com/osinfra-io/opentofu-google-project?ref=912e5f1e334e46f8048109e79ed4f30b32c036f1" # v0.6.0
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=912e5f1e334e46f8048109e79ed4f30b32c036f1" # v0.6.0
 
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = var.project_cis_2_2_logging_sink_project_id

--- a/deployments/regional/backend.tofu
+++ b/deployments/regional/backend.tofu
@@ -1,1 +1,13 @@
-../shared/backend.tofu
+# Backend Configuration
+# https://opentofu.org/docs/language/settings/backends/configuration
+
+terraform {
+  # Google Cloud Storage
+  # https://opentofu.org/docs/language/settings/backends/gcs
+
+  backend "gcs" {
+    bucket             = var.state_bucket
+    kms_encryption_key = var.state_kms_encryption_key
+    prefix             = var.state_prefix
+  }
+}

--- a/deployments/regional/helpers.tofu
+++ b/deployments/regional/helpers.tofu
@@ -1,1 +1,11 @@
-../shared/helpers.tofu
+# OpenTofu Core Helpers Module (osinfra.io)
+# https://github.com/osinfra-io/pt-arche-core-helpers
+
+module "helpers" {
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+
+  cost_center         = "x001"
+  data_classification = "public"
+  repository          = "backstage"
+  team                = "platform-backstage"
+}

--- a/deployments/shared/helpers.tofu
+++ b/deployments/shared/helpers.tofu
@@ -1,8 +1,8 @@
 # OpenTofu Core Helpers Module (osinfra.io)
-# https://github.com/osinfra-io/opentofu-core-helpers
+# https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "helpers" {
-  source = "github.com/osinfra-io/opentofu-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
 
   cost_center         = "x001"
   data_classification = "public"


### PR DESCRIPTION
## Summary

Update all references from the old `opentofu-*` repo names to their new `pt-arche-*` names following the repository renames.

### Renamed repos

| Old name | New name |
|---|---|
| `opentofu-core-helpers` | `pt-arche-core-helpers` |
| `opentofu-datadog-google-integration` | `pt-arche-datadog-google-integration` |
| `opentofu-google-kubernetes-engine` | `pt-arche-google-kubernetes-engine` |
| `opentofu-google-network` | `pt-arche-google-network` |
| `opentofu-google-project` | `pt-arche-google-project` |
| `opentofu-google-storage-bucket` | `pt-arche-google-storage-bucket` |
| `opentofu-kubernetes-cert-manager` | `pt-arche-kubernetes-cert-manager` |
| `opentofu-kubernetes-datadog-operator` | `pt-arche-kubernetes-datadog-operator` |
| `opentofu-kubernetes-istio` | `pt-arche-kubernetes-istio` |
| `opentofu-kubernetes-opa-gatekeeper` | `pt-arche-kubernetes-opa-gatekeeper` |

### Files updated

- `*.tofu` — module `source` references and URL comments
- `*.md` — badge URLs, GitHub links, prose
- `*.yaml`/`*.yml` — catalog-info component names and project slugs