### PR TITLE
Update arche module versions

### DIFF
--- a/deployments/helpers.tofu
+++ b/deployments/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"
   data_classification = "public"

--- a/deployments/main.tofu
+++ b/deployments/main.tofu
@@ -16,7 +16,7 @@ module "datadog" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=d51e04061b1a0f73ea56252cdc58eed01fb17e8e" # v0.6.7
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=39a041123cc3154c651e47c6aa69c2ead4c4577b" # v0.6.7
 
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = var.project_cis_2_2_logging_sink_project_id

--- a/deployments/main.tofu
+++ b/deployments/main.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-datadog-google-integration
 
 module "datadog" {
-  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=3e87e321842678ad478ba2c8d007a7685338e8d7" # v0.3.5
+  source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=a0f6388bd28937e49871f3e717740cf6775507ca" # v0.4.1
   count  = var.datadog_enable ? 1 : 0
 
   api_key                            = var.datadog_api_key
@@ -16,7 +16,7 @@ module "datadog" {
 # https://github.com/osinfra-io/pt-arche-google-project
 
 module "project" {
-  source = "github.com/osinfra-io/pt-arche-google-project?ref=912e5f1e334e46f8048109e79ed4f30b32c036f1" # v0.6.0
+  source = "github.com/osinfra-io/pt-arche-google-project?ref=d51e04061b1a0f73ea56252cdc58eed01fb17e8e" # v0.6.7
 
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = var.project_cis_2_2_logging_sink_project_id

--- a/deployments/regional/helpers.tofu
+++ b/deployments/regional/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"
   data_classification = "public"

--- a/deployments/shared/helpers.tofu
+++ b/deployments/shared/helpers.tofu
@@ -2,7 +2,7 @@
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
 module "helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=30d987aa83c8dc51b35370021d88444ae76957ee" # v0.1.2
+  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"
   data_classification = "public"


### PR DESCRIPTION
Update arche module versions:

- pt-arche-core-helpers v0.2.1
- pt-arche-datadog-google-integration v0.4.1
- pt-arche-google-kubernetes-engine v0.3.2
- pt-arche-google-network v0.3.2
- pt-arche-google-project v0.6.7
- pt-arche-google-storage-bucket v0.3.1
- pt-arche-kubernetes-cert-manager v0.2.1
- pt-arche-kubernetes-datadog-operator v0.3.2
- pt-arche-kubernetes-istio v0.3.2
- pt-arche-kubernetes-opa-gatekeeper v0.2.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure module dependencies across deployment configurations to latest stable versions
  * Helpers module upgraded from v0.1.2 to v0.2.1
  * Datadog integration module upgraded from v0.3.5 to v0.4.1
  * Google project module upgraded from v0.6.0 to v0.6.7

<!-- end of auto-generated comment: release notes by coderabbit.ai -->