### PR TITLE
Align with platform instruction conventions

### DIFF
--- a/deployments/backend.tofu
+++ b/deployments/backend.tofu
@@ -1,13 +1,1 @@
-# Backend Configuration
-# https://opentofu.org/docs/language/settings/backends/configuration
-
-terraform {
-  # Google Cloud Storage
-  # https://opentofu.org/docs/language/settings/backends/gcs
-
-  backend "gcs" {
-    bucket             = var.state_bucket
-    kms_encryption_key = var.state_kms_encryption_key
-    prefix             = var.state_prefix
-  }
-}
+shared/backend.tofu

--- a/deployments/helpers.tofu
+++ b/deployments/helpers.tofu
@@ -1,7 +1,7 @@
 # OpenTofu Core Helpers Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
-module "helpers" {
+module "core_helpers" {
   source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"

--- a/deployments/locals.tofu
+++ b/deployments/locals.tofu
@@ -3,9 +3,9 @@
 
 locals {
   datadog_count                      = var.datadog_enable ? 1 : 0
-  datadog_mci_synthetic_url          = module.helpers.environment == "production" ? "https://backstage.gcp.osinfra.io/health" : "https://backstage.${module.helpers.env}.gcp.osinfra.io/health"
-  datadog_synthetic_message_critical = module.helpers.environment == "production" ? "@hangouts-Platform-CriticalHighPriority" : ""
-  datadog_synthetic_message_medium   = module.helpers.environment == "production" ? "@hangouts-Platform-MediumLowInfoPriority" : ""
+  datadog_mci_synthetic_url          = module.core_helpers.environment == "production" ? "https://backstage.gcp.osinfra.io/health" : "https://backstage.${module.core_helpers.env}.gcp.osinfra.io/health"
+  datadog_synthetic_message_critical = module.core_helpers.environment == "production" ? "@hangouts-Platform-CriticalHighPriority" : ""
+  datadog_synthetic_message_medium   = module.core_helpers.environment == "production" ? "@hangouts-Platform-MediumLowInfoPriority" : ""
   datadog_synthetic_name             = "Backstage"
   datadog_synthetic_service          = "backstage"
 
@@ -21,13 +21,13 @@ locals {
       message          = local.datadog_synthetic_message_medium
       message_priority = "3"
       name             = "Ingress ${local.datadog_synthetic_name}"
-      region           = module.helpers.region
+      region           = module.core_helpers.region
       service          = local.datadog_synthetic_service
       status           = "paused"
-      url              = module.helpers.environment == "production" ? "https://backstage.gcp.osinfra.io" : "https://backstage.${module.helpers.env}.gcp.osinfra.io"
+      url              = module.core_helpers.environment == "production" ? "https://backstage.gcp.osinfra.io" : "https://backstage.${module.core_helpers.env}.gcp.osinfra.io"
     }
   }
 
-  kubernetes_project = module.helpers.environment == "sandbox" ? "plt-k8s-tf39-sb" : module.helpers.environment == "production" ? "plt-k8s-tf10-prod" : "plt-k8s-tf33-nonprod"
-  registry           = module.helpers.environment == "sandbox" ? "us-docker.pkg.dev/plt-lz-services-tf7f-sb/plt-docker-virtual" : "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
+  kubernetes_project = module.core_helpers.environment == "sandbox" ? "plt-k8s-tf39-sb" : module.core_helpers.environment == "production" ? "plt-k8s-tf10-prod" : "plt-k8s-tf33-nonprod"
+  registry           = module.core_helpers.environment == "sandbox" ? "us-docker.pkg.dev/plt-lz-services-tf7f-sb/plt-docker-virtual" : "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
 }

--- a/deployments/main.tofu
+++ b/deployments/main.tofu
@@ -1,28 +1,28 @@
 # Datadog Google Cloud Platform Integration Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-datadog-google-integration
 
-module "datadog" {
+module "datadog_google_integration" {
   source = "github.com/osinfra-io/pt-arche-datadog-google-integration?ref=a0f6388bd28937e49871f3e717740cf6775507ca" # v0.4.1
   count  = local.datadog_count
 
   api_key                            = var.datadog_api_key
   is_cspm_enabled                    = true
   is_security_command_center_enabled = true
-  labels                             = module.helpers.labels
-  project                            = module.project.id
+  labels                             = module.core_helpers.labels
+  project                            = module.google_project.id
 }
 
 # Google Project Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-google-project
 
-module "project" {
+module "google_project" {
   source = "github.com/osinfra-io/pt-arche-google-project?ref=39a041123cc3154c651e47c6aa69c2ead4c4577b" # v0.6.7
 
   billing_account                 = var.project_billing_account
   cis_2_2_logging_sink_project_id = var.project_cis_2_2_logging_sink_project_id
   description                     = "backstage"
   folder_id                       = var.project_folder_id
-  labels                          = module.helpers.labels
+  labels                          = module.core_helpers.labels
   monthly_budget_amount           = var.project_monthly_budget_amount
   prefix                          = "plt"
 
@@ -44,6 +44,6 @@ module "project" {
 
 resource "google_project_iam_member" "cloud_sql_proxy" {
   member  = "serviceAccount:${var.k8s_workload_identity_service_account}"
-  project = module.project.id
+  project = module.google_project.id
   role    = "roles/cloudsql.client"
 }

--- a/deployments/moved.tofu
+++ b/deployments/moved.tofu
@@ -1,0 +1,17 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+moved {
+  from = module.datadog
+  to   = module.datadog_google_integration
+}
+
+moved {
+  from = module.helpers
+  to   = module.core_helpers
+}
+
+moved {
+  from = module.project
+  to   = module.google_project
+}

--- a/deployments/regional/backend.tofu
+++ b/deployments/regional/backend.tofu
@@ -1,13 +1,1 @@
-# Backend Configuration
-# https://opentofu.org/docs/language/settings/backends/configuration
-
-terraform {
-  # Google Cloud Storage
-  # https://opentofu.org/docs/language/settings/backends/gcs
-
-  backend "gcs" {
-    bucket             = var.state_bucket
-    kms_encryption_key = var.state_kms_encryption_key
-    prefix             = var.state_prefix
-  }
-}
+../shared/backend.tofu

--- a/deployments/regional/helpers.tofu
+++ b/deployments/regional/helpers.tofu
@@ -1,7 +1,7 @@
 # OpenTofu Core Helpers Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
-module "helpers" {
+module "core_helpers" {
   source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"

--- a/deployments/regional/locals.tofu
+++ b/deployments/regional/locals.tofu
@@ -2,13 +2,13 @@
 # https://opentofu.org/docs/language/values/locals
 
 locals {
-  datadog_mci_synthetic_url          = module.helpers.environment == "production" ? "https://gcp.osinfra.io/${local.datadog_synthetic_service}/metadata/cluster-name" : "https://${module.helpers.env}.gcp.osinfra.io/${local.datadog_synthetic_service}/metadata/cluster-name"
-  datadog_synthetic_message_critical = module.helpers.environment == "production" ? "@hangouts-Platform-CriticalHighPriority" : ""
-  datadog_synthetic_message_medium   = module.helpers.environment == "production" ? "@hangouts-Platform-MediumLowInfoPriority" : ""
+  datadog_mci_synthetic_url          = module.core_helpers.environment == "production" ? "https://gcp.osinfra.io/${local.datadog_synthetic_service}/metadata/cluster-name" : "https://${module.core_helpers.env}.gcp.osinfra.io/${local.datadog_synthetic_service}/metadata/cluster-name"
+  datadog_synthetic_message_critical = module.core_helpers.environment == "production" ? "@hangouts-Platform-CriticalHighPriority" : ""
+  datadog_synthetic_message_medium   = module.core_helpers.environment == "production" ? "@hangouts-Platform-MediumLowInfoPriority" : ""
   datadog_synthetic_name             = "Backstage"
   datadog_synthetic_service          = "backstage"
 
-  datadog_synthetic_tests = module.helpers.region == "us-east1" || module.helpers.zone == "b" ? {
+  datadog_synthetic_tests = module.core_helpers.region == "us-east1" || module.core_helpers.zone == "b" ? {
     "us-east1" = {
       locations = [
         "aws:us-east-1",
@@ -20,10 +20,11 @@ locals {
       message          = local.datadog_synthetic_message_medium
       message_priority = "3"
       name             = "Istio Ingress ${local.datadog_synthetic_name}"
-      region           = module.helpers.region
+      region           = module.core_helpers.region
+      request_headers  = module.core_helpers.region == "global" ? {} : { Body = "services-${module.core_helpers.region}" }
       service          = local.datadog_synthetic_service
       status           = "paused"
-      url              = module.helpers.environment == "production" ? "https://backstage.gcp.osinfra.io" : "https://backstage.${module.helpers.env}.gcp.osinfra.io"
+      url              = module.core_helpers.environment == "production" ? "https://backstage.gcp.osinfra.io" : "https://backstage.${module.core_helpers.env}.gcp.osinfra.io"
     }
   } : {}
 
@@ -39,10 +40,10 @@ locals {
     "backstage.appConfig.app.baseUrl"                    = var.backstage_app_config_base_url
     "backstage.appConfig.backend.baseUrl"                = var.backstage_app_config_base_url
     "backstage.appConfig.backend.cors.origin"            = var.backstage_app_config_base_url
-    "backstage.extraContainers[0].args[2]"               = "${data.google_project.backstage.project_id}:${module.helpers.region}:${module.cloud_sql.instance}"
+    "backstage.extraContainers[0].args[2]"               = "${data.google_project.backstage.project_id}:${module.core_helpers.region}:${module.cloud_sql.instance}"
     "backstage.image.registry"                           = local.registry
     "backstage.image.tag"                                = var.backstage_version
-    "backstage.podLabels.tags\\.datadoghq\\.com/env"     = module.helpers.environment
+    "backstage.podLabels.tags\\.datadoghq\\.com/env"     = module.core_helpers.environment
     "backstage.podLabels.tags\\.datadoghq\\.com/version" = var.backstage_version
     "backstage.replicas"                                 = var.backstage_replicas
     # "backstage.resources.limits.cpu"                     = var.backstage_resources_limits_cpu
@@ -51,9 +52,9 @@ locals {
     # "backstage.resources.requests.memory"                = var.backstage_resources_requests_memory
   }
 
-  hostname           = module.helpers.environment == "production" ? "backstage-${module.helpers.region}.gcp.osinfra.io" : "backstage-${module.helpers.region}.${module.helpers.env}.gcp.osinfra.io"
-  kubernetes_project = module.helpers.environment == "sandbox" ? "plt-k8s-tf39-sb" : module.helpers.environment == "production" ? "plt-k8s-tf10-prod" : "plt-k8s-tf33-nonprod"
+  hostname           = module.core_helpers.environment == "production" ? "backstage-${module.core_helpers.region}.gcp.osinfra.io" : "backstage-${module.core_helpers.region}.${module.core_helpers.env}.gcp.osinfra.io"
+  kubernetes_project = module.core_helpers.environment == "sandbox" ? "plt-k8s-tf39-sb" : module.core_helpers.environment == "production" ? "plt-k8s-tf10-prod" : "plt-k8s-tf33-nonprod"
   main               = data.terraform_remote_state.main.outputs
-  managed_zone       = module.helpers.environment == "production" ? "gcp-osinfra-io" : "${module.helpers.env}-gcp-osinfra-io"
-  registry           = module.helpers.environment == "sandbox" ? "us-docker.pkg.dev/plt-lz-services-tf7f-sb/plt-docker-virtual" : "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
+  managed_zone       = module.core_helpers.environment == "production" ? "gcp-osinfra-io" : "${module.core_helpers.env}-gcp-osinfra-io"
+  registry           = module.core_helpers.environment == "sandbox" ? "us-docker.pkg.dev/plt-lz-services-tf7f-sb/plt-docker-virtual" : "us-docker.pkg.dev/plt-lz-services-tf79-prod/plt-docker-virtual"
 }

--- a/deployments/regional/main.tofu
+++ b/deployments/regional/main.tofu
@@ -7,10 +7,10 @@ data "terraform_remote_state" "main" {
   config = {
     bucket             = var.remote_bucket
     kms_encryption_key = var.state_kms_encryption_key
-    prefix             = module.helpers.repository
+    prefix             = module.core_helpers.repository
   }
 
-  workspace = "main-${module.helpers.environment}"
+  workspace = "main-${module.core_helpers.environment}"
 }
 
 # Google Cloud SQL Module (osinfra.io)
@@ -22,11 +22,11 @@ module "cloud_sql" {
   deletion_protection            = false
   host_project_id                = var.networking_project_id
   instance_name                  = "backstage"
-  labels                         = module.helpers.labels
+  labels                         = module.core_helpers.labels
   network                        = "standard-shared"
   point_in_time_recovery_enabled = false
   project                        = data.google_project.backstage.project_id
-  region                         = module.helpers.region
+  region                         = module.core_helpers.region
 }
 
 # Datadog Synthetics Test Resource
@@ -49,17 +49,17 @@ resource "datadog_synthetics_test" "this" {
 
   locations = each.value.locations
   message   = each.value.message
-  name      = "${each.value.name} ${each.value.region} ${module.helpers.environment}"
+  name      = "${each.value.name} ${each.value.region} ${module.core_helpers.environment}"
 
   options_list {
-    tick_every = 300
+    monitor_priority = each.value.message_priority
 
     retry {
       count    = 2
       interval = 120
     }
 
-    monitor_priority = each.value.message_priority
+    tick_every = 300
   }
 
   request_definition {
@@ -67,18 +67,16 @@ resource "datadog_synthetics_test" "this" {
     url    = each.value.url
   }
 
-  request_headers = each.value.region == "global" ? {} : {
-    Body = "services-${each.value.region}"
-  }
+  request_headers = each.value.request_headers
 
   status  = each.value.status
   subtype = "http"
 
   tags = [
-    "env:${module.helpers.environment}",
+    "env:${module.core_helpers.environment}",
     "service:${each.value.service}",
     "region:${each.value.region}",
-    "team:${module.helpers.team}"
+    "team:${module.core_helpers.team}"
   ]
 
   type = "api"
@@ -88,13 +86,14 @@ resource "datadog_synthetics_test" "this" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/resources/dns_record_set
 
 resource "google_dns_record_set" "backstage_a_record" {
-  project      = var.networking_project_id
-  name         = "${local.hostname}." # Trailing dot is required
   managed_zone = local.managed_zone
-  type         = "A"
-  ttl          = 300
+  name         = "${local.hostname}." # Trailing dot is required
+  project      = var.networking_project_id
 
   rrdatas = [kubernetes_ingress_v1.backstage.status.0.load_balancer.0.ingress.0.ip]
+
+  ttl  = 300
+  type = "A"
 }
 
 # Cloud SQL Database Resource
@@ -122,6 +121,12 @@ resource "google_sql_user" "this" {
 # https://search.opentofu.org/provider/hashicorp/helm/latest/docs/resources/release
 
 resource "helm_release" "backstage" {
+  depends_on = [
+    kubernetes_secret_v1.github_app_credentials,
+    kubernetes_secret_v1.postgres,
+    module.cloud_sql
+  ]
+
   chart      = "backstage"
   name       = "backstage"
   namespace  = "backstage"
@@ -133,27 +138,26 @@ resource "helm_release" "backstage" {
   ]
 
   version = "2.6.0"
-
-  depends_on = [
-    kubernetes_secret_v1.github_app_credentials,
-    kubernetes_secret_v1.postgres,
-    module.cloud_sql
-  ]
 }
 
 # Kubernetes Ingress Resource
 # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs/resources/ingress_v1
 
 resource "kubernetes_ingress_v1" "backstage" {
-  metadata {
-    name      = "backstage"
-    namespace = "backstage"
+  depends_on = [
+    module.cloud_sql
+  ]
 
+  metadata {
     annotations = {
       "kubernetes.io/ingress.allow-http"       = "false"
       "networking.gke.io/managed-certificates" = kubernetes_manifest.backstage_tls.manifest.metadata.name
     }
+
+    name      = "backstage"
+    namespace = "backstage"
   }
+
   spec {
     rule {
       host = local.hostname
@@ -172,16 +176,12 @@ resource "kubernetes_ingress_v1" "backstage" {
       }
     }
   }
-  wait_for_load_balancer = true
 
-  depends_on = [
-    module.cloud_sql
-  ]
+  wait_for_load_balancer = true
 }
 
 # Kubernetes Manifest Resource
 # https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs/resources/manifest
-
 
 resource "kubernetes_manifest" "backstage_tls" {
   manifest = {
@@ -200,13 +200,13 @@ resource "kubernetes_manifest" "backstage_tls" {
 }
 
 # Kubernetes Secret Resource
-# https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs/resources/secret
+# https://search.opentofu.org/provider/hashicorp/kubernetes/latest/docs/resources/secret_v1
 
 resource "kubernetes_secret_v1" "github_app_credentials" {
   data = {
-    GITHUB_APP_ID             = var.github_app_id
     GITHUB_APP_CLIENT_ID      = var.github_app_client_id
     GITHUB_APP_CLIENT_SECRET  = var.github_app_client_secret
+    GITHUB_APP_ID             = var.github_app_id
     GITHUB_APP_PRIVATE_KEY    = base64decode(var.github_app_private_key)
     GITHUB_APP_WEBHOOK_SECRET = var.github_app_webhook_secret
     GITHUB_AUTH_CLIENT_ID     = var.github_auth_client_id

--- a/deployments/regional/moved.tofu
+++ b/deployments/regional/moved.tofu
@@ -1,0 +1,7 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+moved {
+  from = module.helpers
+  to   = module.core_helpers
+}

--- a/deployments/regional/providers.tofu
+++ b/deployments/regional/providers.tofu
@@ -109,8 +109,8 @@ data "google_client_config" "this" {
 # # https://search.opentofu.org/provider/hashicorp/google/latest/docs/data-sources/container_cluster
 
 data "google_container_cluster" "this" {
-  name     = "plt-${module.helpers.region}-${module.helpers.zone}"
-  location = module.helpers.region
+  location = module.core_helpers.region
+  name     = "plt-${module.core_helpers.region}-${module.core_helpers.zone}"
   project  = data.google_project.k8s.project_id
 }
 
@@ -118,11 +118,11 @@ data "google_container_cluster" "this" {
 # https://search.opentofu.org/provider/hashicorp/google/latest/docs/data-sources/projects
 
 data "google_projects" "backstage" {
-  filter = "name:plt-backstage-* labels.env:${module.helpers.environment}"
+  filter = "name:plt-backstage-* labels.env:${module.core_helpers.environment}"
 }
 
 data "google_projects" "k8s" {
-  filter = "name:plt-k8s-* labels.env:${module.helpers.environment}"
+  filter = "name:plt-k8s-* labels.env:${module.core_helpers.environment}"
 }
 
 # Google Project Data Source

--- a/deployments/regional/variables.tofu
+++ b/deployments/regional/variables.tofu
@@ -66,16 +66,16 @@ variable "github_app_client_id" {
   default     = "Iv23liBR7fZfikt1WnLb"
 }
 
-variable "github_app_id" {
-  description = "GitHub App ID"
-  type        = number
-  default     = 1102240
-}
-
 variable "github_app_client_secret" {
   description = "GitHub App Client Secret"
   type        = string
   sensitive   = true
+}
+
+variable "github_app_id" {
+  description = "GitHub App ID"
+  type        = number
+  default     = 1102240
 }
 
 variable "github_app_private_key" {

--- a/deployments/shared/helpers.tofu
+++ b/deployments/shared/helpers.tofu
@@ -1,7 +1,7 @@
 # OpenTofu Core Helpers Module (osinfra.io)
 # https://github.com/osinfra-io/pt-arche-core-helpers
 
-module "helpers" {
+module "core_helpers" {
   source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
 
   cost_center         = "x001"

--- a/deployments/shared/moved.tofu
+++ b/deployments/shared/moved.tofu
@@ -1,0 +1,7 @@
+# Moved Blocks
+# https://opentofu.org/docs/language/moved
+
+moved {
+  from = module.helpers
+  to   = module.core_helpers
+}


### PR DESCRIPTION
Align codebase with updated platform instruction conventions from pt-ai-context.

Changes include:
- Rename `module "helpers"` to `module "core_helpers"` and update all references
- Fix module naming convention (strip `pt-arche-` prefix, replace hyphens with underscores)
- Remove duplicate comment blocks (one per resource type)
- Fix alphabetical ordering of variables, locals, and block arguments
- Move inline conditional logic from main.tofu to locals.tofu
- Fix for_each plural naming (singular → plural, excluding `this`)
- Fix argument ordering (meta-arguments first, then alphabetical)
- Additional repo-specific fixes (symlinks, test fixtures, etc.)

Part of a platform-wide alignment effort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Deployment configuration reorganized and consolidated across environments.
  * State mappings added to preserve existing infrastructure state after refactoring.
* **Refactor**
  * Centralized environment/region identity references and updated integrations (Datadog, Google Project) and regional settings to use the centralized helper values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->