### PR TITLE
Replace duplicate files with symlinks to shared/

### DIFF
--- a/deployments/helpers.tofu
+++ b/deployments/helpers.tofu
@@ -1,11 +1,1 @@
-# OpenTofu Core Helpers Module (osinfra.io)
-# https://github.com/osinfra-io/pt-arche-core-helpers
-
-module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
-
-  cost_center         = "x001"
-  data_classification = "public"
-  repository          = "backstage"
-  team                = "platform-backstage"
-}
+shared/helpers.tofu

--- a/deployments/regional/helpers.tofu
+++ b/deployments/regional/helpers.tofu
@@ -1,11 +1,1 @@
-# OpenTofu Core Helpers Module (osinfra.io)
-# https://github.com/osinfra-io/pt-arche-core-helpers
-
-module "core_helpers" {
-  source = "github.com/osinfra-io/pt-arche-core-helpers//root?ref=9734175404f3c0b26b0a58a6c877828dba2dea70" # v0.2.1
-
-  cost_center         = "x001"
-  data_classification = "public"
-  repository          = "backstage"
-  team                = "platform-backstage"
-}
+../shared/helpers.tofu


### PR DESCRIPTION
Replaces duplicate .tofu files with relative symlinks pointing to the canonical copy in shared/, following the updated platform instructions.

No logic changes — symlinked files are byte-for-byte identical to the files they replace.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized deployment helper files for improved modularity and reusability across regional deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->